### PR TITLE
Improve calculation of intensity for Monte Carlo

### DIFF
--- a/B8_project/diffraction_monte_carlo.py
+++ b/B8_project/diffraction_monte_carlo.py
@@ -90,8 +90,8 @@ class NeutronDiffractionMonteCarlo:
                                       trials_per_batch: int = 10000,
                                       unit_cells_in_crystal: tuple[int, int, int] = (
                                       8, 8, 8),
-                                      min_angle_rad: float = 0.0,
-                                      max_angle_rad: float = np.pi,
+                                      min_angle_deg: float = 0.0,
+                                      max_angle_deg: float = 180.0,
                                       angle_bins: int = 100):
         """
         Calculate diffraction pattern
@@ -125,7 +125,7 @@ class NeutronDiffractionMonteCarlo:
             fewer unhelpful trials resulting in destructive interference are accepted.
         """
         k = 2 * np.pi / self.wavelength
-        two_thetas = np.linspace(min_angle_rad, max_angle_rad, angle_bins)
+        two_thetas = np.linspace(min_angle_deg, max_angle_deg, angle_bins)
         intensities = np.zeros(angle_bins)
 
         # read relevant neutron scattering lengths
@@ -167,13 +167,13 @@ class NeutronDiffractionMonteCarlo:
                     np.exp(1j * scattering_vecs @ r.T), axis=1)
 
             dot_products = np.einsum("ij,ij->i", k_vecs, k_primes)
-            two_theta_batch = np.arccos(dot_products / k**2)
+            two_theta_batch = np.degrees(np.arccos(dot_products / k**2))
             intensity_batch = np.abs(structure_factors)**2
 
             stats.total_trials += trials_per_batch
 
-            angles_accepted = np.where(np.logical_and(two_theta_batch > min_angle_rad,
-                                                      two_theta_batch < max_angle_rad))
+            angles_accepted = np.where(np.logical_and(two_theta_batch > min_angle_deg,
+                                                      two_theta_batch < max_angle_deg))
             two_theta_batch = two_theta_batch[angles_accepted]
             intensity_batch = intensity_batch[angles_accepted]
 
@@ -183,6 +183,5 @@ class NeutronDiffractionMonteCarlo:
             stats.accepted_data_points += two_theta_batch.shape[0]
 
         intensities /= np.max(intensities)
-        two_thetas = np.degrees(two_thetas)
 
         return two_thetas, intensities

--- a/B8_project/diffraction_monte_carlo.py
+++ b/B8_project/diffraction_monte_carlo.py
@@ -1,3 +1,17 @@
+"""
+Diffraction Monte Carlo
+===========
+
+This module contains classes to calculate diffraction spectra using Monte Carlo methods.
+
+Classes
+-------
+    - `NeutronDiffractionMonteCarloRunStats`: A class to store statistics associated
+    with each run of `calculate_diffraction_pattern`.
+    - `NeutronDiffractionMonteCarlo`: A class to calculate neutron diffraction
+    patterns, with different optimizations based on the type of crystal
+"""
+
 import time
 from dataclasses import dataclass
 import numpy as np
@@ -168,7 +182,6 @@ class NeutronDiffractionMonteCarlo:
 
             # dot_products.shape = (batch_trials, n_atoms)
             dot_products = np.einsum("ik,jk", scattering_vecs, all_atom_pos)
-            t4 = time.time()
 
             # exp_terms.shape = (batch_trials, n_atoms)
             exps = np.exp(1j * dot_products)

--- a/scripts/calculate_monte_carlo_nd.py
+++ b/scripts/calculate_monte_carlo_nd.py
@@ -5,7 +5,6 @@ from B8_project import file_reading
 import B8_project.crystal as unit_cell
 from B8_project.diffraction_monte_carlo import NeutronDiffractionMonteCarlo
 
-
 LATTICE_FILE = "data/PrO2_lattice.csv"
 BASIS_FILE = "data/PrO2_basis.csv"
 
@@ -17,35 +16,18 @@ my_cell = unit_cell.UnitCell.new_unit_cell(basis, lattice)
 nd = NeutronDiffractionMonteCarlo(my_cell, 0.123)
 
 # TODO: better handling of whether to calculate or read from file
-two_thetas, intensities = nd.calculate_diffraction_pattern(200)
+two_thetas, intensities = (
+    nd.calculate_diffraction_pattern(300000,
+                                     min_angle_rad=np.radians(18),
+                                     max_angle_rad=np.radians(57)))
 np.savetxt('two_thetas.txt', two_thetas)
 np.savetxt('intensities.txt', intensities)
 
 two_thetas = np.loadtxt("two_thetas.txt")
 intensities = np.loadtxt("intensities.txt")
 
-indices = np.where(np.logical_and(two_thetas >= 18, two_thetas <= 57))
-two_thetas = two_thetas[indices]
-intensities = intensities[indices]
-intensities = intensities / np.max(intensities)
-
-NUM_BINS = 60
-min_theta = np.min(two_thetas)
-max_theta = np.max(two_thetas)
-bin_size = (max_theta - min_theta) / NUM_BINS
-two_theta_bins = np.linspace(min_theta + bin_size / 2, max_theta - bin_size / 2,
-                             NUM_BINS)
-intensities_binned = np.zeros(NUM_BINS)
-for i in range(two_thetas.size):
-    bin_i = int((two_thetas[i] - min_theta) // bin_size)
-    if bin_i == NUM_BINS:
-        continue
-    intensities_binned[bin_i] += intensities[i]
-intensities_binned /= np.max(intensities_binned)
-
-plt.scatter(two_thetas, intensities, s=2, label="Scattering trials")
-plt.plot(two_theta_bins, intensities_binned, color='k',
-         label="Aggregated intensities")
+# plt.scatter(two_thetas, intensities, s=2, label="Intensity")
+plt.plot(two_thetas, intensities, color='k', label="Intensity")
 plt.xlabel("Scattering angle (2θ) (deg)")
 plt.ylabel("Normalized intensity")
 plt.title("PrO2 Neutron Diffraction Spectrum")

--- a/scripts/calculate_monte_carlo_nd.py
+++ b/scripts/calculate_monte_carlo_nd.py
@@ -19,7 +19,8 @@ nd = NeutronDiffractionMonteCarlo(my_cell, 0.123)
 two_thetas, intensities = (
     nd.calculate_diffraction_pattern(300000,
                                      min_angle_deg=18,
-                                     max_angle_deg=57))
+                                     max_angle_deg=57,
+                                     angle_bins=200))
 np.savetxt('two_thetas.txt', two_thetas)
 np.savetxt('intensities.txt', intensities)
 

--- a/scripts/calculate_monte_carlo_nd.py
+++ b/scripts/calculate_monte_carlo_nd.py
@@ -18,8 +18,8 @@ nd = NeutronDiffractionMonteCarlo(my_cell, 0.123)
 # TODO: better handling of whether to calculate or read from file
 two_thetas, intensities = (
     nd.calculate_diffraction_pattern(300000,
-                                     min_angle_rad=np.radians(18),
-                                     max_angle_rad=np.radians(57)))
+                                     min_angle_deg=18,
+                                     max_angle_deg=57))
 np.savetxt('two_thetas.txt', two_thetas)
 np.savetxt('intensities.txt', intensities)
 

--- a/scripts/calculate_monte_carlo_nd.py
+++ b/scripts/calculate_monte_carlo_nd.py
@@ -1,31 +1,51 @@
+"""
+This script calculates the diffraction peaks for PrO2 using Monte Carlo and plots the
+spectrum.
+"""
+
+from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
-
 from B8_project import file_reading
 import B8_project.crystal as unit_cell
 from B8_project.diffraction_monte_carlo import NeutronDiffractionMonteCarlo
 
-LATTICE_FILE = "data/PrO2_lattice.csv"
-BASIS_FILE = "data/PrO2_basis.csv"
+two_thetas_file = Path("two_thetas.txt")
+intensities_file = Path("intensities.txt")
+if two_thetas_file.is_file() or intensities_file.is_file():
+    while True:
+        res = input(
+                "Previous scattering intensity data found in 'two_thetas.txt' or "
+                "'intensities.txt'. Plot existing data? [y/n]")
+        if res.lower() == "y":
+            CALCULATE_SPECTRUM = False
+            break
+        if res.lower() == "n":
+            CALCULATE_SPECTRUM = True
+            break
+else:
+    CALCULATE_SPECTRUM = False
 
-lattice = file_reading.read_lattice(LATTICE_FILE)
+if CALCULATE_SPECTRUM:
+    LATTICE_FILE = "data/PrO2_lattice.csv"
+    BASIS_FILE = "data/PrO2_basis.csv"
 
-basis = file_reading.read_basis(BASIS_FILE)
+    lattice = file_reading.read_lattice(LATTICE_FILE)
+    basis = file_reading.read_basis(BASIS_FILE)
 
-my_cell = unit_cell.UnitCell.new_unit_cell(basis, lattice)
-nd = NeutronDiffractionMonteCarlo(my_cell, 0.123)
+    unit_cell = unit_cell.UnitCell.new_unit_cell(basis, lattice)
+    nd = NeutronDiffractionMonteCarlo(unit_cell, 0.123)
 
-# TODO: better handling of whether to calculate or read from file
-two_thetas, intensities = (
-    nd.calculate_diffraction_pattern(300000,
-                                     min_angle_deg=18,
-                                     max_angle_deg=57,
-                                     angle_bins=200))
-np.savetxt('two_thetas.txt', two_thetas)
-np.savetxt('intensities.txt', intensities)
-
-two_thetas = np.loadtxt("two_thetas.txt")
-intensities = np.loadtxt("intensities.txt")
+    two_thetas, intensities = (
+        nd.calculate_diffraction_pattern(30000,
+                                         min_angle_deg=18,
+                                         max_angle_deg=57,
+                                         angle_bins=200))
+    np.savetxt('two_thetas.txt', two_thetas)
+    np.savetxt('intensities.txt', intensities)
+else:
+    two_thetas = np.loadtxt("two_thetas.txt")
+    intensities = np.loadtxt("intensities.txt")
 
 # plt.scatter(two_thetas, intensities, s=2, label="Intensity")
 plt.plot(two_thetas, intensities, color='k', label="Intensity")
@@ -34,4 +54,3 @@ plt.ylabel("Normalized intensity")
 plt.title("PrO2 Neutron Diffraction Spectrum")
 plt.legend()
 plt.show()
-print(f"{my_cell}")

--- a/tests/test_diffraction_monte_carlo.py
+++ b/tests/test_diffraction_monte_carlo.py
@@ -3,8 +3,6 @@ Add module docstring here.
 """
 
 import pytest
-
-# import pytest_mock
 import numpy as np
 import numpy.testing as nptest
 from B8_project.file_reading import read_lattice, read_basis
@@ -72,37 +70,15 @@ def test_monte_carlo_calculate_diffraction_pattern(nd_monte_carlo, mocker):
         unit_cells_in_crystal=(8, 8, 8),
         min_angle_deg=0,
         max_angle_deg=180,
-        intensity_threshold_factor=0.0,
+        angle_bins=10
     )
 
-    expected_two_thetas = np.array(
-        [
-            162.63819148,
-            65.67386965,
-            16.90391563,
-            83.593794,
-            83.70605006,
-            90.91048647,
-            7.53356425,
-            44.00035372,
-            79.02876523,
-            158.61472377,
-        ]
-    )
-    expected_intensities = np.array(
-        [
-            2.489788e-05,
-            3.136013e-02,
-            7.809854e-02,
-            2.148601e-06,
-            3.446430e-02,
-            6.286620e-06,
-            8.349908e-05,
-            2.231075e-04,
-            7.179199e-06,
-            1.000000e00,
-        ]
-    )
+    expected_two_thetas = np.array([0., 20., 40., 60., 80., 100., 120., 140., 160.,
+                                    180.])
+    expected_intensities = np.array([0.000000e+00, 8.349908e-05, 0.000000e+00,
+                                     2.231075e-04, 7.179199e-06, 6.286620e-06,
+                                     0.000000e+00, 0.000000e+00, 1.000000e+00,
+                                     2.489788e-05])
 
     nptest.assert_allclose(two_thetas, expected_two_thetas, rtol=1e-6)
     nptest.assert_allclose(intensities, expected_intensities, rtol=1e-6)

--- a/tests/test_diffraction_monte_carlo.py
+++ b/tests/test_diffraction_monte_carlo.py
@@ -70,8 +70,8 @@ def test_monte_carlo_calculate_diffraction_pattern(nd_monte_carlo, mocker):
         target_accepted_trials=10,
         trials_per_batch=10,
         unit_cells_in_crystal=(8, 8, 8),
-        min_angle_rad=0,
-        max_angle_rad=180,
+        min_angle_deg=0,
+        max_angle_deg=180,
         intensity_threshold_factor=0.0,
     )
 

--- a/tests/test_diffraction_monte_carlo.py
+++ b/tests/test_diffraction_monte_carlo.py
@@ -1,5 +1,5 @@
 """
-Add module docstring here.
+This module contains unit tests for the diffraction_monte_carlo.py module.
 """
 
 import pytest
@@ -13,7 +13,8 @@ from B8_project.diffraction_monte_carlo import NeutronDiffractionMonteCarlo
 @pytest.fixture
 def nd_monte_carlo():
     """
-    Add test docstring here.
+    Returns instance of `NeutronDiffractionMonteCarlo`, containing data for NaCl and
+    wavelength of 0.123nm
     """
     nacl_lattice = read_lattice("tests/data/NaCl_lattice.csv")
     nacl_basis = read_basis("tests/data/NaCl_basis.csv")
@@ -55,9 +56,11 @@ random_unit_vectors_2 = np.array(
 
 def test_monte_carlo_calculate_diffraction_pattern(nd_monte_carlo, mocker):
     """
-    Mocks the `random_uniform_unit_vectors` method to return the same random
-    vectors for consistent result.
+    A unit test for the Monte Carlo calculate_diffraction_pattern function. This unit
+    test tests normal operation of the function.
     """
+    # Mocks the `random_uniform_unit_vectors` method to return the same random
+    # vectors for consistent result.
     mocker.patch(
         "B8_project.utils.random_uniform_unit_vectors",
         side_effect=[random_unit_vectors_1, random_unit_vectors_2],


### PR DESCRIPTION
Closes: #15 

- Aggregate intensity before returning results, instead of returning a list of data points representing individual trials
  - Remove `intensity_threshold_factor` and add `angle_bins` to parameters
- Handle minimum and maximum angle in degrees
- Ask for user input on whether to calculate new spectrum or read from existing data
- Fully vectorize calculation to remove for loop over atoms in unit cell
- Improve docstrings